### PR TITLE
Add Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: ruby
+cache: bundler
+rvm:
+  - 2.1.5
+addons:
+  postgresql: "9.4"
+before_script:
+  - psql -c 'create database factorio_mods_test;' -U postgres
+  - cp config/database.yml.travis config/database.yml
+  - bundle exec rake db:schema:load db:seed
+script: bundle exec spring rspec

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Factorio Mods
+# Factorio Mods [![Build Status](https://travis-ci.org/Zequez/FactorioMods.svg)](https://travis-ci.org/Zequez/FactorioMods)
 
 [FactorioMods.com](http://factoriomods.com) it's an open
 source web app to host Factorio Mods, and make it easier for user and devs alike

--- a/config/database.yml.travis
+++ b/config/database.yml.travis
@@ -1,0 +1,6 @@
+# Database config for Travis-CI
+test:
+  adapter: postgresql
+  encoding: unicode
+  database: factorio_mods_test
+  pool: 5


### PR DESCRIPTION
Travis-CI is a continuous integration service that is free for open-source projects. This changeset includes a `.travis.yml` configuration which configures the CI environment, a `config/database.yml.travis` to tell that environment to connect to the right database, and a fancypants Travis-CI badge for the README.

Builds look like [this](https://travis-ci.org/willglynn/FactorioMods/builds/71586535). When integrated with GitHub, Travis-CI will automatically build each pull request and provide status in the pull request UI, and it will automatically build and warn you if `master` has any failing tests.

Please [sign up for Travis-CI](http://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI%3A) and enable the FactorioMods repository before merging.
