### PR TITLE
Align category icons to the right

### DIFF
--- a/app/views/mods/_filter_bar.html.haml
+++ b/app/views/mods/_filter_bar.html.haml
@@ -16,6 +16,6 @@
       - @categories.each do |category|
         %li.category-filter
           = category_link category do
-            %i{class: category.icon_class}
             = category.name
             (#{category_probabilistic_count(category)})
+            %i{class: category.icon_class}


### PR DESCRIPTION
It looks more aesthetic this way because the icons line up, no?
